### PR TITLE
Triangle count

### DIFF
--- a/Packages/com.tripp.leximperialis/Editor/ModelJudicator.cs
+++ b/Packages/com.tripp.leximperialis/Editor/ModelJudicator.cs
@@ -261,7 +261,7 @@ namespace TRIPP.LexImperialis.Editor
         }
 
 
-            private bool HasOverlappingTriangles(Mesh mesh, Vector2[] uvs)
+        private bool HasOverlappingTriangles(Mesh mesh, Vector2[] uvs)
         {
             int[] triangles = mesh.triangles;
 

--- a/Packages/com.tripp.leximperialis/Editor/ModelJudicator.cs
+++ b/Packages/com.tripp.leximperialis/Editor/ModelJudicator.cs
@@ -8,7 +8,7 @@ namespace TRIPP.LexImperialis.Editor
     [CreateAssetMenu(fileName = "ModelJudicator", menuName = "ScriptableObjects/LexImperialis/ModelJudicator")]
     public class ModelJudicator : ImporterJudicator
     {
-        public int maxTriangleCount = 1000;
+        public int maxTriangleCountLOD4 = 1000;
         public override Judgment Adjudicate(Object accused)
         {
             Judgment judgement = base.Adjudicate(accused);
@@ -227,7 +227,7 @@ namespace TRIPP.LexImperialis.Editor
                         triCount += subMesh.triangles.Length;
                     }
 
-                    if (triCount > maxTriangleCount)
+                    if (triCount > maxTriangleCountLOD4)
                     {
                         result = new List<Infraction>
                     {
@@ -242,7 +242,7 @@ namespace TRIPP.LexImperialis.Editor
 
                 foreach (Mesh subMesh in subMeshes)
                 {
-                    if (subMesh.name.Contains("LOD4") && subMesh.triangles.Length > maxTriangleCount)
+                    if (subMesh.name.Contains("LOD4") && subMesh.triangles.Length > maxTriangleCountLOD4)
                     {
                         result = new List<Infraction>
                     {

--- a/Packages/com.tripp.leximperialis/Editor/ModelJudicator.cs
+++ b/Packages/com.tripp.leximperialis/Editor/ModelJudicator.cs
@@ -174,19 +174,20 @@ namespace TRIPP.LexImperialis.Editor
         {
             Infraction result = null;
             GameObject rootObject = AssetDatabase.LoadAssetAtPath<GameObject>(AssetDatabase.GetAssetPath(modelImporter));
-            if (rootObject.transform.localPosition != Vector3.zero)
+            if (rootObject.GetComponents<Component>().Count() > 1)
             {
+                if(rootObject.transform.localPosition != Vector3.zero)
                 result = new Infraction
                 {
                     isFixable = false,
                     message = $"{rootObject.name}: The pivot is not set at the origin (0,0,0)"
                 };
             }
-            else if(rootObject.GetComponents<Component>().Count() != 1)
+            else if(rootObject.GetComponents<Component>().Count() == 1)
             {
                 for (int i = 0; i < rootObject.transform.childCount; i++)
                 {
-                    if (rootObject.transform.GetChild(i).transform.position != Vector3.zero)
+                    if (rootObject.transform.GetChild(i).transform.localPosition != Vector3.zero)
                     {
                         result = new Infraction
                         {

--- a/Packages/com.tripp.leximperialis/Editor/ModelJudicator.cs
+++ b/Packages/com.tripp.leximperialis/Editor/ModelJudicator.cs
@@ -208,52 +208,7 @@ namespace TRIPP.LexImperialis.Editor
             return result;
         }
 
-        private List<Infraction> CheckForTriCountInfractions(ModelImporter modelImporter, bool useOverload = false)
-        {
-            List<Infraction> result = null;
-            List<Mesh> subMeshes = GetSubMeshes(modelImporter);
-            GameObject rootObject = AssetDatabase.LoadAssetAtPath<GameObject>(AssetDatabase.GetAssetPath(modelImporter));
-
-
-            if (rootObject.name.Contains("LOD4"))
-            {
-                int triCount = 0;
-                foreach (Mesh subMesh in subMeshes)
-                { 
-                    triCount += subMesh.triangles.Length;
-                }
-
-                if(triCount > maxTriangleCount)
-                {
-                    result = new List<Infraction>
-                    {
-                        new Infraction
-                        {
-                            isFixable = false,
-                            message = $"{rootObject.name} - {modelImporter.GetInstanceID()} exceeds the Tri Count limit for LOD4s"
-                        }
-                    };
-                }
-            }
-
-            foreach (Mesh subMesh in subMeshes)
-            {
-                if (subMesh.name.Contains("LOD4") && subMesh.triangles.Length > maxTriangleCount)
-                {
-                    result = new List<Infraction>
-                    {
-                        new Infraction
-                        {
-                            isFixable = false,
-                            message = $"{rootObject.name} - {modelImporter.GetInstanceID()} exceeds the Tri Count limit for LOD4s"
-                        }
-                    };
-                }
-            }
-
-            return result;
-
-        }
+        
 
         private List<Infraction> CheckForTriCountInfractions(ModelImporter modelImporter)
         {
@@ -299,33 +254,7 @@ namespace TRIPP.LexImperialis.Editor
                     }
                 }
 
-                /*if (triCount > maxTriCount)
-                    result.Add(new Infraction
-                    {
-                        isFixable = false,
-                        message = $"{mesh.name} - {mesh.GetInstanceID()} exceeds the Tri Count limit for meshes in general"
-                    });*/
-            
-
-
-            //List<Mesh> meshList = GetSubMeshes(modelImporter);
-
-            /*foreach (Mesh m in meshList)
-            {
-                checkTriangleCounts(m, lod4MaxTriCount, maxTriCount, ref result);
-            }*/
-
-            //If the root has a mesh
-            //if (rootObject.GetComponent<MeshFilter>() != null)
-            //    checkTriangleCounts(rootObject.GetComponent<MeshFilter>(), lod4MaxTriCount, maxTriCount, ref result);
-            //if has children, check them as well
-            /*if(rootObject.GetComponentInChildren<MeshFilter>() != null)
-                foreach (MeshFilter m in rootObject.GetComponentsInChildren<MeshFilter>())
-                {
-                    Debug.Log(rootObject.name);
-                    checkTriangleCounts(m, lod4MaxTriCount, maxTriCount, ref result);
-                }
-            */
+                
             return result;
 
         }

--- a/Packages/com.tripp.leximperialis/package.json
+++ b/Packages/com.tripp.leximperialis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.tripp.leximperialis",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "displayName": "Lex Imperialis",
   "description": "In the grim darkness of the far future, there is only war. To stray from the path of the Emperor's light is to invite chaos and destruction upon oneself. Obey the rules, or face the wrath of the Imperium.\r\n\r\nThe Lex Imperialis is a comprehensive toolset designed to empower technical teams in implementing Unity Editor standards efficiently. It presents these standards in an accessible and organized format within a user-friendly interface. By streamlining adherence to guidelines, it enhances productivity and fosters a cohesive development environment, allowing content creators to focus on core tasks while ensuring compliance with industry standards.",
   "unity": "2022.3",


### PR DESCRIPTION
# [CPF-3110](https://trippinc.atlassian.net/browse/CPF-3110)
- [x] Updated Version
- [x] Updated Change Log
# Description
The Model Judicator now has the ability to check for tricounts in the models that correspond to the LOD4.
# Testing
Please create a checklist of what to test for.
- [ ] Model Judicator can successfully detect tricounts on LOD4s that are larger than they should be.


[CPF-3110]: https://trippinc.atlassian.net/browse/CPF-3110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ