### PR TITLE
Machine Spirit Caching Logic

### DIFF
--- a/Packages/com.tripp.leximperialis/package.json
+++ b/Packages/com.tripp.leximperialis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.tripp.leximperialis",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "displayName": "Lex Imperialis",
   "description": "In the grim darkness of the far future, there is only war. To stray from the path of the Emperor's light is to invite chaos and destruction upon oneself. Obey the rules, or face the wrath of the Imperium.\r\n\r\nThe Lex Imperialis is a comprehensive toolset designed to empower technical teams in implementing Unity Editor standards efficiently. It presents these standards in an accessible and organized format within a user-friendly interface. By streamlining adherence to guidelines, it enhances productivity and fosters a cohesive development environment, allowing content creators to focus on core tasks while ensuring compliance with industry standards.",
   "unity": "2022.3",


### PR DESCRIPTION
# {CPF-3322 #}
- [x] Updated Version
- [x] Updated Change Log
# Description
Added caching logic to LexImperialisMachineSpirit. Objects that were previously deemed to be good will not run again. This will persist even if Unity is close. This is because we also added a binary file to record the data.
# Testing
Please create a checklist of what to test for.
- [x] Create any of the object that Lex Imperialis can check: textures, materials, or particle system.
- [x] Set the object to not be inline with the current preset.
- [x] Pass Judgment on the object and hit "Fix". Once the object is fix if pass judgment again this object will be skip.
- [x] Close Unity and pass judgment again on the same object to check if persistent work.
