### PR TITLE
Cpf 3310 multiple preset support

### DIFF
--- a/Packages/com.tripp.leximperialis/Editor/ImporterJudicator.cs
+++ b/Packages/com.tripp.leximperialis/Editor/ImporterJudicator.cs
@@ -186,6 +186,28 @@ namespace TRIPP.LexImperialis.Editor
             return result;
         }
 
+        public override string ServitudeImperpituis(Judgment judgment, Infraction infraction, Preset chosenPreset)
+        {
+            string result = "Failed to apply preset.";
+            if (judgment == null || infraction == null || chosenPreset == null)
+                return result;
+
+            AssetImporter importer = AssetImporter.GetAtPath(AssetDatabase.GetAssetPath(judgment.accused));
+            if (importer == null)
+                return result;
+
+            if (chosenPreset.CanBeAppliedTo(importer))
+            {
+                chosenPreset.ApplyTo(importer);
+                result = $"Successfully mind-wiped, reprogrammed, and cybernetically-enhanced {judgment.accused.name}.";
+                RemoveInfraction(judgment, infraction);
+
+                importer.SaveAndReimport();
+            }
+            return result;
+        }
+
+
         public override string ServitudeImperpituis(Judgment judgment, Infraction infraction)
         {
             string result = "Failed to apply preset.";

--- a/Packages/com.tripp.leximperialis/Editor/Judicator.cs
+++ b/Packages/com.tripp.leximperialis/Editor/Judicator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using UnityEditor.Presets;
 using UnityEngine;
 
 namespace TRIPP.LexImperialis.Editor
@@ -19,6 +20,14 @@ namespace TRIPP.LexImperialis.Editor
         /// <param name="infraction">The infraction to base the string on.</param>
         /// <returns>A string representing the servitude imperpituis.</returns>
         public abstract string ServitudeImperpituis(Judgment judgment, Infraction infraction);
+
+        public virtual string ServitudeImperpituis(Judgment judgment, Infraction infraction, Preset chosenPreset)
+        {
+            // By default, do nothing or just return a fallback message.
+            // This ensures all other Judicators compile fine.
+            return "Not implemented for this Judicator type.";
+        }
+
 
         /// <summary>
         /// Creates a new judgment or adds an infraction to an existing judgment.

--- a/Packages/com.tripp.leximperialis/Editor/LexImperialisCogitator.cs
+++ b/Packages/com.tripp.leximperialis/Editor/LexImperialisCogitator.cs
@@ -63,7 +63,8 @@ namespace TRIPP.LexImperialis.Editor
 
             // Move Select/Deselect All button below the toolbar
             GUILayout.BeginHorizontal();
-            if (GUILayout.Button("Select/Deselect All", GUILayout.Width(120)))
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button("Select/Deselect All Judicators"))
             {
                 bool enableAll = !filterDictionary.Values.Any(enabled => enabled);
                 foreach (var key in filterDictionary.Keys.ToList())
@@ -71,10 +72,9 @@ namespace TRIPP.LexImperialis.Editor
                     filterDictionary[key] = enableAll;
                 }
             }
+            GUILayout.FlexibleSpace();
             GUILayout.EndHorizontal();
-
             EditorGUILayout.Space();
-
             _scrollPosition = EditorGUILayout.BeginScrollView(_scrollPosition);
             switch (_toolbarIndex)
             {
@@ -113,12 +113,8 @@ namespace TRIPP.LexImperialis.Editor
             }
         }
 
-
-
         private void DisplayAbitesJudge()
         {
-
-
             if (Selection.count != 0)
             {
                 GUILayout.BeginHorizontal();
@@ -141,7 +137,7 @@ namespace TRIPP.LexImperialis.Editor
 
                 if (GUILayout.Button("Pass Judgment"))
                 {
-                    judgments = machineSpirit.PassJudgement(filterDictionary); // Using the original method
+                    judgments = machineSpirit.PassJudgement(filterDictionary); 
                 }
             }
 
@@ -158,10 +154,8 @@ namespace TRIPP.LexImperialis.Editor
                             {
                                 infractionFoldouts[judgment.accused] = false;
                             }
-
                             EditorGUILayout.BeginVertical("Box");
 
-                            // Begin Horizontal Layout
                             EditorGUILayout.BeginHorizontal();
 
                             // Foldout arrow
@@ -171,63 +165,11 @@ namespace TRIPP.LexImperialis.Editor
                                 true,
                                 EditorStyles.foldout
                             );
-
-                            // Adjust spacing to bring the icon and name closer to the arrow
-                            GUILayout.Space(-730); // Negative space to bring the elements closer
-
-                            // ObjectField for Icon and Name
                             EditorGUILayout.ObjectField(judgment.accused, typeof(Object), false, GUILayout.ExpandWidth(true));
+                            GUILayout.FlexibleSpace();
+                            GUILayout.EndHorizontal();
 
-                            // End Horizontal Layout
-                            EditorGUILayout.EndHorizontal();
-
-                            // If expanded, show infractions
-                            if (infractionFoldouts[judgment.accused])
-                            {
-                                EditorGUILayout.BeginVertical("Box");
-                                for (int i = 0; i < judgment.infractions.Count; i++)
-                                {
-                                    Infraction infraction = judgment.infractions[i];
-                                    if (infraction != null)
-                                    {
-                                        EditorGUILayout.BeginHorizontal("Box");
-                                        EditorGUILayout.LabelField(infraction.message);
-                                        if (infraction.isFixable)
-                                        {
-
-                                            ImporterJudicator importerJudicator = judgment.judicator as ImporterJudicator;
-                                            if (importerJudicator != null &&
-                                                importerJudicator.presets != null &&
-                                                importerJudicator.presets.Count > 1)
-                                            {
-                                                // Display multiple fix buttons
-                                                foreach (var preset in importerJudicator.presets)
-                                                {
-                                                    if (preset == null) continue;
-
-                                                    if (GUILayout.Button($"Fix with {preset.name}"))
-                                                    {
-                                                        _message = importerJudicator.ServitudeImperpituis(judgment, infraction, preset);
-                                                        _randomMessageIsSet = false;
-                                                    }
-                                                }
-                                            }
-                                            else
-                                            {
-                                                // fallback single fix
-                                                if (GUILayout.Button("Fix"))
-                                                {
-                                                    _message = judgment.judicator.ServitudeImperpituis(judgment, infraction);
-                                                    _randomMessageIsSet = false;
-                                                }
-                                            }
-
-                                        }
-                                        EditorGUILayout.EndHorizontal();
-                                    }
-                                }
-                                EditorGUILayout.EndVertical();
-                            }
+                            DrawInfractions(judgment, infractionFoldouts);
 
                             EditorGUILayout.EndVertical();
                         }
@@ -246,8 +188,64 @@ namespace TRIPP.LexImperialis.Editor
                     _randomMessageIsSet = true;
                 }
             }
+        }
 
+        private void DrawInfractions(Judgment judgment, Dictionary<Object, bool> infractionFoldouts)
+        {
+            // Check if the foldout is expanded for this judgment
+            if (infractionFoldouts[judgment.accused])
+            {
+                EditorGUILayout.BeginVertical("Box");
 
+                // Iterate through the list of infractions
+                for (int i = 0; i < judgment.infractions.Count; i++)
+                {
+                    Infraction infraction = judgment.infractions[i];
+                    if (infraction != null)
+                    {
+                        EditorGUILayout.BeginHorizontal("Box");
+
+                        // Display the infraction message
+                        EditorGUILayout.LabelField(infraction.message);
+
+                        // Check if the infraction is fixable
+                        if (infraction.isFixable)
+                        {
+                            ImporterJudicator importerJudicator = judgment.judicator as ImporterJudicator;
+                            if (importerJudicator != null &&
+                                importerJudicator.presets != null &&
+                                importerJudicator.presets.Count > 1)
+                            {
+                                // Display multiple fix buttons for each preset
+                                foreach (var preset in importerJudicator.presets)
+                                {
+                                    if (preset == null)
+                                        continue;
+
+                                    if (GUILayout.Button($"Fix with {preset.name}"))
+                                    {
+                                        _message = importerJudicator.ServitudeImperpituis(judgment, infraction, preset);
+                                        _randomMessageIsSet = false;
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                // Fallback: Single fix button
+                                if (GUILayout.Button("Fix"))
+                                {
+                                    _message = judgment.judicator.ServitudeImperpituis(judgment, infraction);
+                                    _randomMessageIsSet = false;
+                                }
+                            }
+                        }
+
+                        EditorGUILayout.EndHorizontal();
+                    }
+                }
+
+                EditorGUILayout.EndVertical();
+            }
         }
 
         private string SetRandomMessage()

--- a/Packages/com.tripp.leximperialis/Editor/LexImperialisCogitator.cs
+++ b/Packages/com.tripp.leximperialis/Editor/LexImperialisCogitator.cs
@@ -27,7 +27,7 @@ namespace TRIPP.LexImperialis.Editor
         private Dictionary<JudicatorFilter, bool> judicatorExpanded = new Dictionary<JudicatorFilter, bool>();
         private Dictionary<JudicatorFilter, Dictionary<Preset, bool>> presetStates = new Dictionary<JudicatorFilter, Dictionary<Preset, bool>>();
         private Dictionary<Object, bool> infractionFoldouts = new Dictionary<Object, bool>();
-        private bool showJudicators = true; // Toggles visibility of all Judicators
+        private bool showJudicators = true; 
 
         private void OnGUI()
         {
@@ -60,10 +60,9 @@ namespace TRIPP.LexImperialis.Editor
             GUILayout.FlexibleSpace();
             GUILayout.EndHorizontal();
             EditorGUILayout.Space();
-
-            // Move Select/Deselect All button below the toolbar
             GUILayout.BeginHorizontal();
             GUILayout.FlexibleSpace();
+
             if (GUILayout.Button("Select/Deselect All Judicators"))
             {
                 bool enableAll = !filterDictionary.Values.Any(enabled => enabled);
@@ -72,6 +71,7 @@ namespace TRIPP.LexImperialis.Editor
                     filterDictionary[key] = enableAll;
                 }
             }
+
             GUILayout.FlexibleSpace();
             GUILayout.EndHorizontal();
             EditorGUILayout.Space();
@@ -120,18 +120,14 @@ namespace TRIPP.LexImperialis.Editor
                 GUILayout.BeginHorizontal();
                 GUILayout.FlexibleSpace();
                 GUILayout.EndHorizontal();
-
                 if (machineSpirit != null)
                 {
-
                     EditorGUILayout.BeginVertical("Box");
-
                     foreach (JudicatorFilter dct in filterDictionary.Keys.ToList())
                     {
                         if (dct != null && dct.judicator != null)
                             filterDictionary[dct] = EditorGUILayout.ToggleLeft(dct.judicator.name, filterDictionary[dct]);
                     }
-
                     EditorGUILayout.EndVertical();
                 }
 
@@ -149,16 +145,13 @@ namespace TRIPP.LexImperialis.Editor
                     {
                         if (judgment != null && judgment.infractions != null && judgment.infractions.Count > 0)
                         {
-                            // Ensure foldout state exists for the judgment
                             if (!infractionFoldouts.ContainsKey(judgment.accused))
                             {
                                 infractionFoldouts[judgment.accused] = false;
                             }
+
                             EditorGUILayout.BeginVertical("Box");
-
                             EditorGUILayout.BeginHorizontal();
-
-                            // Foldout arrow
                             infractionFoldouts[judgment.accused] = EditorGUILayout.Foldout(
                                 infractionFoldouts[judgment.accused],
                                 GUIContent.none,
@@ -168,9 +161,7 @@ namespace TRIPP.LexImperialis.Editor
                             EditorGUILayout.ObjectField(judgment.accused, typeof(Object), false, GUILayout.ExpandWidth(true));
                             GUILayout.FlexibleSpace();
                             GUILayout.EndHorizontal();
-
                             DrawInfractions(judgment, infractionFoldouts);
-
                             EditorGUILayout.EndVertical();
                         }
                     }
@@ -192,23 +183,17 @@ namespace TRIPP.LexImperialis.Editor
 
         private void DrawInfractions(Judgment judgment, Dictionary<Object, bool> infractionFoldouts)
         {
-            // Check if the foldout is expanded for this judgment
             if (infractionFoldouts[judgment.accused])
             {
                 EditorGUILayout.BeginVertical("Box");
-
-                // Iterate through the list of infractions
                 for (int i = 0; i < judgment.infractions.Count; i++)
                 {
                     Infraction infraction = judgment.infractions[i];
                     if (infraction != null)
                     {
                         EditorGUILayout.BeginHorizontal("Box");
-
-                        // Display the infraction message
                         EditorGUILayout.LabelField(infraction.message);
 
-                        // Check if the infraction is fixable
                         if (infraction.isFixable)
                         {
                             ImporterJudicator importerJudicator = judgment.judicator as ImporterJudicator;
@@ -216,7 +201,6 @@ namespace TRIPP.LexImperialis.Editor
                                 importerJudicator.presets != null &&
                                 importerJudicator.presets.Count > 1)
                             {
-                                // Display multiple fix buttons for each preset
                                 foreach (var preset in importerJudicator.presets)
                                 {
                                     if (preset == null)
@@ -231,7 +215,6 @@ namespace TRIPP.LexImperialis.Editor
                             }
                             else
                             {
-                                // Fallback: Single fix button
                                 if (GUILayout.Button("Fix"))
                                 {
                                     _message = judgment.judicator.ServitudeImperpituis(judgment, infraction);
@@ -239,11 +222,9 @@ namespace TRIPP.LexImperialis.Editor
                                 }
                             }
                         }
-
                         EditorGUILayout.EndHorizontal();
                     }
                 }
-
                 EditorGUILayout.EndVertical();
             }
         }

--- a/Packages/com.tripp.leximperialis/Editor/LexImperialisCogitator.cs
+++ b/Packages/com.tripp.leximperialis/Editor/LexImperialisCogitator.cs
@@ -233,11 +233,33 @@ namespace TRIPP.LexImperialis.Editor
                                         EditorGUILayout.LabelField(infraction.message);
                                         if (infraction.isFixable)
                                         {
-                                            if (GUILayout.Button("Fix"))
+                                            ImporterJudicator importerJudicator = judgment.judicator as ImporterJudicator;
+                                            if (importerJudicator != null &&
+                                                importerJudicator.presets != null &&
+                                                importerJudicator.presets.Count > 1)
                                             {
-                                                _message = judgment.judicator.ServitudeImperpituis(judgment, infraction);
-                                                _randomMessageIsSet = false;
+                                                // Display multiple fix buttons
+                                                foreach (var preset in importerJudicator.presets)
+                                                {
+                                                    if (preset == null) continue;
+
+                                                    if (GUILayout.Button($"Fix with {preset.name}"))
+                                                    {
+                                                        _message = importerJudicator.ServitudeImperpituis(judgment, infraction, preset);
+                                                        _randomMessageIsSet = false;
+                                                    }
+                                                }
                                             }
+                                            else
+                                            {
+                                                // fallback single fix
+                                                if (GUILayout.Button("Fix"))
+                                                {
+                                                    _message = judgment.judicator.ServitudeImperpituis(judgment, infraction);
+                                                    _randomMessageIsSet = false;
+                                                }
+                                            }
+
                                         }
                                         EditorGUILayout.EndHorizontal();
                                     }

--- a/Packages/com.tripp.leximperialis/Editor/LexImperialisCogitator.cs
+++ b/Packages/com.tripp.leximperialis/Editor/LexImperialisCogitator.cs
@@ -117,6 +117,8 @@ namespace TRIPP.LexImperialis.Editor
 
         private void DisplayAbitesJudge()
         {
+
+
             if (Selection.count != 0)
             {
                 GUILayout.BeginHorizontal();
@@ -125,56 +127,15 @@ namespace TRIPP.LexImperialis.Editor
 
                 if (machineSpirit != null)
                 {
-                    int columnCount = 0;
+
                     EditorGUILayout.BeginVertical("Box");
-                    GUILayout.BeginHorizontal();
 
-                    foreach (JudicatorFilter filter in filterDictionary.Keys.ToList())
+                    foreach (JudicatorFilter dct in filterDictionary.Keys.ToList())
                     {
-                        if (filter != null && filter.judicator != null)
-                        {
-                            // Start a new column every 3 Judicators
-                            if (columnCount >= 3)
-                            {
-                                GUILayout.EndHorizontal();
-                                GUILayout.BeginHorizontal();
-                                columnCount = 0;
-                            }
-
-                            GUILayout.BeginVertical("Box", GUILayout.Width(300));
-                            GUILayout.BeginHorizontal();
-
-                            filterDictionary[filter] = EditorGUILayout.Toggle(filterDictionary[filter], GUILayout.Width(20)); // Checkbox first
-
-                            // Check if Judicator has 2 or more presets
-                            if (presetStates.ContainsKey(filter) && presetStates[filter].Count > 1)
-                            {
-                                judicatorExpanded[filter] = EditorGUILayout.Foldout(judicatorExpanded[filter], filter.judicator.name, true); // Dropdown arrow and name
-                            }
-                            else
-                            {
-                                // If fewer than 2 presets, just display the name
-                                EditorGUILayout.LabelField(filter.judicator.name);
-                            }
-
-                            GUILayout.EndHorizontal();
-
-                            if (judicatorExpanded[filter] && presetStates.ContainsKey(filter))
-                            {
-                                EditorGUILayout.BeginVertical("box"); // Show presets if expanded
-                                foreach (var preset in presetStates[filter].Keys.ToList())
-                                {
-                                    presetStates[filter][preset] = EditorGUILayout.ToggleLeft(preset.name, presetStates[filter][preset]);
-                                }
-                                EditorGUILayout.EndVertical();
-                            }
-
-                            GUILayout.EndVertical();
-                            columnCount++;
-                        }
+                        if (dct != null && dct.judicator != null)
+                            filterDictionary[dct] = EditorGUILayout.ToggleLeft(dct.judicator.name, filterDictionary[dct]);
                     }
 
-                    GUILayout.EndHorizontal();
                     EditorGUILayout.EndVertical();
                 }
 
@@ -233,6 +194,7 @@ namespace TRIPP.LexImperialis.Editor
                                         EditorGUILayout.LabelField(infraction.message);
                                         if (infraction.isFixable)
                                         {
+
                                             ImporterJudicator importerJudicator = judgment.judicator as ImporterJudicator;
                                             if (importerJudicator != null &&
                                                 importerJudicator.presets != null &&

--- a/Packages/com.tripp.leximperialis/Editor/PrefabJudicator.cs
+++ b/Packages/com.tripp.leximperialis/Editor/PrefabJudicator.cs
@@ -127,13 +127,13 @@ namespace TRIPP.LexImperialis.Editor
             Transform targetTransform = prefab.transform.Find(particleSystemPath);
             if (targetTransform == null)
             {
-                return $"Could not find the ParticleSystem at path: {particleSystemPath}.";
+                return $"Failed to find the ParticleSystem at path: {particleSystemPath}.";
             }
 
             ParticleSystem targetParticleSystem = targetTransform.GetComponent<ParticleSystem>();
             if (targetParticleSystem == null)
             {
-                return $"Could not find a ParticleSystem at path: {particleSystemPath}.";
+                return $"Failed to find a ParticleSystem at path: {particleSystemPath}.";
             }
 
             // Access the serialized object of the ParticleSystem

--- a/Packages/com.tripp.leximperialis/Editor/PrefabJudicator.cs
+++ b/Packages/com.tripp.leximperialis/Editor/PrefabJudicator.cs
@@ -9,140 +9,151 @@ namespace TRIPP.LexImperialis.Editor
     [CreateAssetMenu(fileName = "PrefabJudicator", menuName = "ScriptableObjects/LexImperialis/PrefabJudicator")]
     public class PrefabJudicator : ImporterJudicator
     {
+        // Adjudicate method to analyze the prefab and identify any infractions
         public override Judgment Adjudicate(UnityEngine.Object accused)
         {
             // Ensure the accused object is a prefab
             GameObject prefab = accused as GameObject;
             if (prefab == null)
             {
-                return null; // Return null if not a prefab
+                return null; // Return null if not a GameObject prefab
             }
 
-            // Check for Particle Systems in the prefab and get infractions
+            // Check for ParticleSystems in the prefab and gather infractions
             List<Infraction> infractions = CheckParticleSystems(prefab);
 
-            // If no infractions were found, return null to suppress default messages
+            // If no infractions are found, return null
             if (infractions == null || infractions.Count == 0)
             {
                 return null;
             }
 
-            // Create the Judgment if infractions were found
-            Judgment judgment = new Judgment
+            // Create and return a Judgment object with identified infractions
+            return new Judgment
             {
-                accused = accused,
+                accused = prefab,
                 judicator = this,
                 infractions = infractions
             };
-
-            return judgment;
         }
 
+        // Method to check all ParticleSystems within the prefab for infractions
         private List<Infraction> CheckParticleSystems(GameObject prefab)
         {
-            if (prefab == null)
-            {
-                Debug.LogError("Prefab is null. Cannot check particle systems.");
-                return null;
-            }
-
+            // Retrieve all ParticleSystems within the prefab
             ParticleSystem[] particleSystems = prefab.GetComponentsInChildren<ParticleSystem>(true);
             if (particleSystems == null || particleSystems.Length == 0)
             {
-                // Silently handle cases where no Particle Systems are found.
-                return null;
+                return null; // Return null if no ParticleSystems are found
             }
 
             if (presets == null || presets.Count == 0)
             {
-                Debug.LogWarning("No presets available for comparison.");
-                return null;
+                return null; // Return null if no presets are available for comparison
             }
 
             List<Infraction> infractions = new List<Infraction>();
 
+            // Loop through each ParticleSystem in the prefab
             foreach (ParticleSystem particleSystem in particleSystems)
             {
+                // Get the path to the ParticleSystem for reporting
+                string particleSystemPath = AnimationUtility.CalculateTransformPath(particleSystem.transform, prefab.transform);
 
+                // Compare each ParticleSystem to the presets
                 foreach (var preset in presets)
                 {
                     if (preset == null)
                     {
-                        Debug.LogWarning("Encountered a null preset.");
-                        continue;
+                        continue; // Skip null presets
                     }
 
-                    // Use the inherited method to check infractions for each ParticleSystem
+                    // Get infractions for the current preset
                     List<Infraction> presetInfractions = GetPresetInfractions(particleSystem, preset);
 
-                    if (presetInfractions == null)
+                    if (presetInfractions != null)
                     {
-                        break;
+                        // Append the ParticleSystem path to each infraction message
+                        foreach (var infraction in presetInfractions)
+                        {
+                            infraction.message = $"{particleSystemPath}: {infraction.message}";
+                        }
+
+                        // Add the infractions to the main list
+                        infractions.AddRange(presetInfractions);
                     }
-
-                    // Check maxParticles against the preset
-                    ParticleSystem.MainModule mainModule = particleSystem.main;
-                    PropertyModification maxParticlesModification = Array.Find(preset.PropertyModifications,
-                        modification => modification.propertyPath.Contains("InitialModule.maxNumParticles"));
-                    int presetMaxParticles = int.Parse(maxParticlesModification.value);
-
-                    // Remove infractions related to maxParticles if within the limit
-                    presetInfractions.RemoveAll(infraction =>
-                        infraction.message.Contains("InitialModule.maxNumParticles") &&
-                        mainModule.maxParticles <= presetMaxParticles);
-
-                    // Add remaining infractions to the main infractions list
-                    infractions.AddRange(presetInfractions);
                 }
             }
 
             return infractions;
         }
 
+        // Method to apply a fix to a specific infraction
         public override string ServitudeImperpituis(Judgment judgment, Infraction infraction)
         {
             string result = "Failed to apply preset.";
 
             if (judgment == null || infraction == null)
             {
-                return result;
+                return result; // Return early if judgment or infraction is null
             }
 
-            GameObject accusedGameObject = judgment.accused as GameObject;
-            if (accusedGameObject == null)
-            {
-                return result;
-            }
-
-            ParticleSystem particleSystem = accusedGameObject.GetComponent<ParticleSystem>();
-            if (particleSystem == null)
-            {
-                return result;
-            }
-
+            // Split the infraction message to extract path, property, and value information
             string[] parts = infraction.message.Split(':');
-            if (parts.Length < 2)
+            if (parts.Length < 3)
             {
-                return result;
+                return "The infraction message format is invalid."; // Return if the message format is incorrect
             }
 
-            string propertyName = parts[0].Trim();
-            string expectedValueString = parts[1].Substring(parts[1].IndexOf("expected") + 8).Split(',')[0].Trim();
+            string particleSystemPath = parts[0].Trim(); // Extract the ParticleSystem path
+            string propertyName = parts[1].Trim(); // Extract the property name
+            string valueInfo = parts[2].Trim(); // Extract expected and found values
 
-            SerializedObject serializedParticleSystem = new SerializedObject(particleSystem);
+            // Extract the expected value from the message
+            string expectedValueString = "";
+            if (valueInfo.Contains("expected"))
+            {
+                int expectedIndex = valueInfo.IndexOf("expected") + 8; // The word "expected" has a length of 8 characters. Adding 8 moves the starting position to the first character after the word "expected"
+                expectedValueString = valueInfo.Substring(expectedIndex).Split(',')[0].Trim();
+            }
+
+            GameObject prefab = judgment.accused as GameObject;
+            if (prefab == null)
+            {
+                return "The accused is not a prefab."; 
+            }
+
+            // Locate the specific ParticleSystem using the path
+            Transform targetTransform = prefab.transform.Find(particleSystemPath);
+            if (targetTransform == null)
+            {
+                return $"Could not find the ParticleSystem at path: {particleSystemPath}.";
+            }
+
+            ParticleSystem targetParticleSystem = targetTransform.GetComponent<ParticleSystem>();
+            if (targetParticleSystem == null)
+            {
+                return $"Could not find a ParticleSystem at path: {particleSystemPath}.";
+            }
+
+            // Access the serialized object of the ParticleSystem
+            SerializedObject serializedParticleSystem = new SerializedObject(targetParticleSystem);
             SerializedProperty property = serializedParticleSystem.FindProperty(propertyName);
 
             if (property == null)
             {
-                return result;
+                return $"The property {propertyName} was not found on the ParticleSystem.";
             }
 
+            // Apply the fix based on the property's type
+            bool applied = false;
             switch (property.propertyType)
             {
                 case SerializedPropertyType.Float:
                     if (float.TryParse(expectedValueString, out float floatValue))
                     {
                         property.floatValue = floatValue;
+                        applied = true;
                         result = $"Updated {propertyName} to {floatValue}.";
                     }
                     break;
@@ -151,6 +162,7 @@ namespace TRIPP.LexImperialis.Editor
                     if (int.TryParse(expectedValueString, out int intValue))
                     {
                         property.intValue = intValue;
+                        applied = true;
                         result = $"Updated {propertyName} to {intValue}.";
                     }
                     break;
@@ -159,12 +171,14 @@ namespace TRIPP.LexImperialis.Editor
                     if (bool.TryParse(expectedValueString, out bool boolValue))
                     {
                         property.boolValue = boolValue;
+                        applied = true;
                         result = $"Updated {propertyName} to {boolValue}.";
                     }
                     break;
 
                 case SerializedPropertyType.String:
                     property.stringValue = expectedValueString;
+                    applied = true;
                     result = $"Updated {propertyName} to {expectedValueString}.";
                     break;
 
@@ -172,28 +186,32 @@ namespace TRIPP.LexImperialis.Editor
                     if (ColorUtility.TryParseHtmlString(expectedValueString, out Color colorValue))
                     {
                         property.colorValue = colorValue;
+                        applied = true;
                         result = $"Updated {propertyName} to {colorValue}.";
                     }
                     break;
 
                 default:
-                    break;
+                    return $"The property type {property.propertyType} is not supported.";
             }
 
-            serializedParticleSystem.ApplyModifiedProperties();
-
-            if (judgment.infractions != null && judgment.infractions.Contains(infraction))
+            if (applied)
             {
-                judgment.infractions.Remove(infraction);
+                // Save changes to the prefab
+                serializedParticleSystem.ApplyModifiedProperties();
+                PrefabUtility.RecordPrefabInstancePropertyModifications(targetParticleSystem);
+                PrefabUtility.SavePrefabAsset(prefab);
 
-                if (judgment.infractions.Count == 0)
+                // Remove the fixed infraction from the judgment
+                judgment.infractions?.Remove(infraction);
+
+                if (judgment.infractions?.Count == 0)
                 {
-                    result = $"Successfully mind-wiped, reprogrammed, and cybernetically-enhanced {judgment.accused.name}.";
+                    result = $"Successfully fixed all infractions for {judgment.accused.name}.";
                 }
             }
 
             return result;
         }
-
     }
 }

--- a/Packages/com.tripp.leximperialis/Editor/PrefabJudicator.cs
+++ b/Packages/com.tripp.leximperialis/Editor/PrefabJudicator.cs
@@ -9,26 +9,21 @@ namespace TRIPP.LexImperialis.Editor
     [CreateAssetMenu(fileName = "PrefabJudicator", menuName = "ScriptableObjects/LexImperialis/PrefabJudicator")]
     public class PrefabJudicator : ImporterJudicator
     {
-        // Adjudicate method to analyze the prefab and identify any infractions
         public override Judgment Adjudicate(UnityEngine.Object accused)
         {
-            // Ensure the accused object is a prefab
             GameObject prefab = accused as GameObject;
             if (prefab == null)
             {
-                return null; // Return null if not a GameObject prefab
+                return null;
             }
 
-            // Check for ParticleSystems in the prefab and gather infractions
             List<Infraction> infractions = CheckParticleSystems(prefab);
 
-            // If no infractions are found, return null
             if (infractions == null || infractions.Count == 0)
             {
                 return null;
             }
 
-            // Create and return a Judgment object with identified infractions
             return new Judgment
             {
                 accused = prefab,
@@ -37,38 +32,33 @@ namespace TRIPP.LexImperialis.Editor
             };
         }
 
-        // Method to check all ParticleSystems within the prefab for infractions
         private List<Infraction> CheckParticleSystems(GameObject prefab)
         {
-            // Retrieve all ParticleSystems within the prefab
             ParticleSystem[] particleSystems = prefab.GetComponentsInChildren<ParticleSystem>(true);
             if (particleSystems == null || particleSystems.Length == 0)
             {
-                return null; // Return null if no ParticleSystems are found
+                return null; 
             }
 
             if (presets == null || presets.Count == 0)
             {
-                return null; // Return null if no presets are available for comparison
+                return null; 
             }
 
             List<Infraction> infractions = new List<Infraction>();
 
-            // Loop through each ParticleSystem in the prefab
             foreach (ParticleSystem particleSystem in particleSystems)
             {
                 // Get the path to the ParticleSystem for reporting
                 string particleSystemPath = AnimationUtility.CalculateTransformPath(particleSystem.transform, prefab.transform);
 
-                // Compare each ParticleSystem to the presets
                 foreach (var preset in presets)
                 {
                     if (preset == null)
                     {
-                        continue; // Skip null presets
+                        continue;
                     }
 
-                    // Get infractions for the current preset
                     List<Infraction> presetInfractions = GetPresetInfractions(particleSystem, preset);
 
                     if (presetInfractions != null)
@@ -79,7 +69,6 @@ namespace TRIPP.LexImperialis.Editor
                             infraction.message = $"{particleSystemPath}: {infraction.message}";
                         }
 
-                        // Add the infractions to the main list
                         infractions.AddRange(presetInfractions);
                     }
                 }
@@ -88,14 +77,13 @@ namespace TRIPP.LexImperialis.Editor
             return infractions;
         }
 
-        // Method to apply a fix to a specific infraction
         public override string ServitudeImperpituis(Judgment judgment, Infraction infraction)
         {
             string result = "Failed to apply preset.";
 
             if (judgment == null || infraction == null)
             {
-                return result; // Return early if judgment or infraction is null
+                return result; 
             }
 
             // Split the infraction message to extract path, property, and value information
@@ -145,7 +133,6 @@ namespace TRIPP.LexImperialis.Editor
                 return $"The property {propertyName} was not found on the ParticleSystem.";
             }
 
-            // Apply the fix based on the property's type
             bool applied = false;
             switch (property.propertyType)
             {
@@ -201,8 +188,6 @@ namespace TRIPP.LexImperialis.Editor
                 serializedParticleSystem.ApplyModifiedProperties();
                 PrefabUtility.RecordPrefabInstancePropertyModifications(targetParticleSystem);
                 PrefabUtility.SavePrefabAsset(prefab);
-
-                // Remove the fixed infraction from the judgment
                 judgment.infractions?.Remove(infraction);
 
                 if (judgment.infractions?.Count == 0)

--- a/Packages/com.tripp.leximperialis/package.json
+++ b/Packages/com.tripp.leximperialis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.tripp.leximperialis",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "displayName": "Lex Imperialis",
   "description": "In the grim darkness of the far future, there is only war. To stray from the path of the Emperor's light is to invite chaos and destruction upon oneself. Obey the rules, or face the wrath of the Imperium.\r\n\r\nThe Lex Imperialis is a comprehensive toolset designed to empower technical teams in implementing Unity Editor standards efficiently. It presents these standards in an accessible and organized format within a user-friendly interface. By streamlining adherence to guidelines, it enhances productivity and fosters a cohesive development environment, allowing content creators to focus on core tasks while ensuring compliance with industry standards.",
   "unity": "2022.3",


### PR DESCRIPTION
# CPF-3310 (Multiple Presets), CPF-3613 (Prefab Judicator)
- [ ] Updated Version
- [x] Updated Change Log
# Description
Update Lex to support multiple presets. Currently for Texture the user can pick between the Default Map preset or the Normal Map preset when they want to apply the changes. Because of the new changes update were also made to PrefabJudicator so that it will probably apply the fix to the child object instead of always applying to the root.
# Testing
Please create a checklist of what to test for.
- [ ] Create as many textures, materials, and particle systems as you want.
- [ ] Pass Judgment on them separately and then group them together and then pass judgment.
- [ ] Put multiple particle system under one prefab and Pass Judgment and hit Fix.
