### PR TITLE
CPF-3308 Added fix all button

### DIFF
--- a/Packages/com.tripp.leximperialis/Editor/ImporterJudicator.cs
+++ b/Packages/com.tripp.leximperialis/Editor/ImporterJudicator.cs
@@ -200,9 +200,8 @@ namespace TRIPP.LexImperialis.Editor
             {
                 chosenPreset.ApplyTo(importer);
                 result = $"Successfully mind-wiped, reprogrammed, and cybernetically-enhanced {judgment.accused.name}.";
-                RemoveInfraction(judgment, infraction);
-
                 importer.SaveAndReimport();
+                judgment.infractions.Clear();
             }
             return result;
         }

--- a/Packages/com.tripp.leximperialis/package.json
+++ b/Packages/com.tripp.leximperialis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.tripp.leximperialis",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "displayName": "Lex Imperialis",
   "description": "In the grim darkness of the far future, there is only war. To stray from the path of the Emperor's light is to invite chaos and destruction upon oneself. Obey the rules, or face the wrath of the Imperium.\r\n\r\nThe Lex Imperialis is a comprehensive toolset designed to empower technical teams in implementing Unity Editor standards efficiently. It presents these standards in an accessible and organized format within a user-friendly interface. By streamlining adherence to guidelines, it enhances productivity and fosters a cohesive development environment, allowing content creators to focus on core tasks while ensuring compliance with industry standards.",
   "unity": "2022.3",


### PR DESCRIPTION
# [CPF-3308](https://trippinc.atlassian.net/browse/CPF-3308)
- [x] Updated Version
- [x] Updated Change Log
# Description
Fixes 
- issues where user was unaware that the preset fix was being applied to the entire importer

Adds
- Functionality to display a Fix All button. The fix all button will do the same thing the fix button previously did for the ImporterJudicator judgments as well as remove all infractions after the fix is applied.
- A drop down that infinitely expandable. This will allow for more than 2 presets to be used for 1 importer type.

# Testing
- [ ] Fix button is still present on all non-importer types.
- [ ] Fix All works for single and multiple presets.
- [ ] After fix is applied all infractions are removed.


[CPF-3308]: https://trippinc.atlassian.net/browse/CPF-3308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ